### PR TITLE
Improve highlighting accuracy compared to compiler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "methodscriptvsc" extension will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.3
+- Improve highlighting accuracy compared to compiler.
+
 ## 0.3.0
 - Add highlighting for functions, operators, numerics, and labels.
 

--- a/syntaxes/mscript.tmLanguage.json
+++ b/syntaxes/mscript.tmLanguage.json
@@ -22,7 +22,7 @@
 		"keywords": {
 			"patterns": [{
 				"name": "keyword.control.mscript",
-				"match": "\\b(as|auto|bind|case|catch|closure|default|do|else|false|finally|for|foreach|iclosure|if|in|instanceof|notinstanceof|null|proc|switch|synchronized|true|try|while)\\b"
+				"match": "\\b(as|auto|bind|case|catch|class|closure|default|do|else|false|finally|for|foreach|iclosure|if|implements|in|instanceof|notinstanceof|null|proc|switch|synchronized|true|try|void|while)\\b"
 			}]
 		},
 		"smart_strings": {
@@ -48,13 +48,13 @@
 		"operators": {
 			"patterns": [{
 				"name": "keyword.operator.mscript",
-				"match": "([=\\<\\>!\\|&%\\+\\-\\*/\\.])"
+				"match": "([=&%/!\\<\\>\\|\\+\\-\\*\\.])"
 			}]
 		},
 		"labels": {
 			"patterns": [{
 				"name": "keyword.other.mscript",
-				"match": "([a-zA-Z_][a-zA-Z0-9_]+)(?=\\s*:)(?=[^\\/])"
+				"match": "([a-zA-Z_][a-zA-Z0-9_]*)(?=\\s*:)(?=[^\\/])"
 			}]
 		},
 		"numerics": {
@@ -85,7 +85,7 @@
 		"interpolated_variable": {
 			"patterns": [{
 				"name": "support.variable.mscript",
-				"match": "@\\{[a-zA-Z0-9_\\[\\]'\"]+}"
+				"match": "@\\{[a-zA-Z0-9_]+}"
 			}]
 		},
 		"file_options": {


### PR DESCRIPTION
Adds more keywords and void, which while not implemented as a keyword, should be treated like one in highlighting.

Adds support for:
```
array(
    label       :   'value',
    labeltwo    :   'othervalue',
)
```
Removes support for:
```
msg("@{array['key']}");
```